### PR TITLE
WIP: Add support for removing pixelation effect

### DIFF
--- a/examples/toggle.rs
+++ b/examples/toggle.rs
@@ -1,0 +1,68 @@
+use bevy::prelude::*;
+use pixelate_mesh::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(PixelateMeshPlugin::<MainCamera>::default())
+        .add_startup_system(setup)
+        .add_system(toggle)
+        .run();
+}
+
+#[derive(Component)]
+struct MainCamera;
+
+fn toggle(
+    mut commands: Commands,
+    query: Query<Entity, With<Pixelate>>,
+    mut pixelate_state: Local<bool>,
+    keys: Res<Input<KeyCode>>,
+) {
+    if keys.just_pressed(KeyCode::Space) {
+        *pixelate_state = !*pixelate_state;
+        for pixelated_entity in &query {
+            // inverted because: Local<T> uses default value and default of bool is false.
+            if !*pixelate_state {
+                commands
+                    .entity(pixelated_entity)
+                    .insert(Pixelate::splat(64));
+            } else {
+                commands.entity(pixelated_entity).remove::<Pixelate>();
+            }
+        }
+    }
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn((
+        Name::new("Cube"),
+        Pixelate::splat(64),
+        PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material: materials.add(Color::WHITE.into()),
+            ..default()
+        },
+    ));
+
+    commands.spawn((
+        Name::new("Camera"),
+        MainCamera,
+        Camera3dBundle {
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+    ));
+
+    commands.spawn((
+        Name::new("Light"),
+        PointLightBundle {
+            transform: Transform::from_translation(Vec3::new(0.0, 10.0, 10.0)),
+            ..default()
+        },
+    ));
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -70,19 +70,23 @@ pub(crate) fn position_canvas<T: Component>(
 pub(crate) fn despawn_dependent_types(
     mut commands: Commands,
     mut removed_pixelate: RemovedComponents<Pixelate>,
-    canvas_query: Query<Entity, With<Canvas>>,
-    pixelation_camera_query: Query<Entity, With<PixelationCamera>>,
+    canvas_query: Query<(Entity, &Canvas)>,
+    pixelation_camera_query: Query<(Entity, &PixelationCamera)>,
 ) {
     for entity in removed_pixelate.iter() {
         debug!("Pixelate was removed from an entity; removing canvas and pixelation camera that held it as target.");
-        for canvas in canvas_query.iter() {
-            if canvas == entity {
-                commands.entity(canvas).despawn_recursive();
+        for (canvas_entity, canvas) in canvas_query.iter() {
+            if canvas.target == entity {
+                debug!("canvas despawned.");
+                commands.entity(canvas_entity).despawn_recursive();
             }
         }
-        for pixelation_camera in pixelation_camera_query.iter() {
-            if pixelation_camera == entity {
-                commands.entity(pixelation_camera).despawn_recursive();
+        for (pixelation_camera_entity, pixelation_camera) in pixelation_camera_query.iter() {
+            if pixelation_camera.target == entity {
+                debug!("camera despawned.");
+                commands
+                    .entity(pixelation_camera_entity)
+                    .despawn_recursive();
             }
         }
     }


### PR DESCRIPTION
I've fixed some bugs in the code where the cameras and canvas entity was compared with the pixelated entity instead of the `target` of `Canvas` and `Camera`.

I haven't really figured out what is left do do. Maybe We need to store the Original `Handle<Mesh>` And reinsert it in `despawn_dependent_types`. 

I could use some help on this one @janhohenheim 